### PR TITLE
Validate locale variant in StringUtils.parseLocaleString

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -950,14 +950,15 @@ public abstract class StringUtils {
 			validateLocalePart(country);
 			return new Locale(language, country);
 		}
-		else if (tokens.length > 2) {
-			String language = tokens[0];
-			validateLocalePart(language);
-			String country = tokens[1];
-			validateLocalePart(country);
-			String variant = Arrays.stream(tokens).skip(2).collect(Collectors.joining(delimiter));
-			return new Locale(language, country, variant);
-		}
+                else if (tokens.length > 2) {
+                        String language = tokens[0];
+                        validateLocalePart(language);
+                        String country = tokens[1];
+                        validateLocalePart(country);
+                        String variant = Arrays.stream(tokens).skip(2).collect(Collectors.joining(delimiter));
+                        validateLocalePart(variant);
+                        return new Locale(language, country, variant);
+                }
 
 		throw new IllegalArgumentException("Invalid locale format: '" + localeString + "'");
 	}

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -720,10 +720,16 @@ class StringUtilsTests {
 		assertThat(locale.getVariant()).as("Variant containing country code not extracted correctly").isEqualTo(variant);
 	}
 
-	@Test  // SPR-14718, SPR-7598
-	void parseJava7Variant() {
-		assertThat(StringUtils.parseLocaleString("sr__#LATN").toString()).isEqualTo("sr__#LATN");
-	}
+        @Test  // SPR-14718, SPR-7598
+        void parseJava7Variant() {
+                assertThat(StringUtils.parseLocaleString("sr__#LATN").toString()).isEqualTo("sr__#LATN");
+        }
+
+        @Test
+        void parseLocaleWithInvalidVariant() {
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                                StringUtils.parseLocaleString("en_US_invalid:variant"));
+        }
 
 	@Test  // SPR-16651
 	void availableLocalesWithLocaleString() {


### PR DESCRIPTION
## Summary
- validate the variant segment in `StringUtils.parseLocaleString`
- add regression test for invalid variant values

## Testing
- `./gradlew :spring-core:test --tests org.springframework.util.StringUtilsTests` *(fails: Plugin [id: 'io.freefair.aggregate-javadoc', version: '8.13.1'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890148938f8832abe3b67b34df529ad